### PR TITLE
Fix for running with TestNG while JUnit 4 is missing on classpath

### DIFF
--- a/cdi-unit/src/main/java/org/jglue/cdiunit/internal/WeldTestUrlDeployment.java
+++ b/cdi-unit/src/main/java/org/jglue/cdiunit/internal/WeldTestUrlDeployment.java
@@ -15,34 +15,21 @@
  */
 package org.jglue.cdiunit.internal;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
-import java.net.MalformedURLException;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.net.URLClassLoader;
-import java.security.CodeSource;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
-import java.util.jar.Attributes;
-import java.util.jar.JarInputStream;
-import java.util.jar.Manifest;
-import java.util.stream.Collectors;
+import org.jboss.weld.bootstrap.api.Bootstrap;
+import org.jboss.weld.bootstrap.api.ServiceRegistry;
+import org.jboss.weld.bootstrap.api.helpers.SimpleServiceRegistry;
+import org.jboss.weld.bootstrap.spi.*;
+import org.jboss.weld.environment.se.WeldSEBeanRegistrant;
+import org.jboss.weld.metadata.BeansXmlImpl;
+import org.jboss.weld.resources.spi.ResourceLoader;
+import org.jglue.cdiunit.*;
+import org.jglue.cdiunit.internal.easymock.EasyMockExtension;
+import org.jglue.cdiunit.internal.jsf.ViewScopeExtension;
+import org.jglue.cdiunit.internal.mockito.MockitoExtension;
+import org.jglue.cdiunit.internal.servlet.*;
+import org.mockito.Mock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.decorator.Decorator;
 import javax.enterprise.inject.Alternative;
@@ -53,36 +40,21 @@ import javax.enterprise.inject.spi.Extension;
 import javax.inject.Inject;
 import javax.inject.Provider;
 import javax.interceptor.Interceptor;
-
-import org.jboss.weld.bootstrap.api.Bootstrap;
-import org.jboss.weld.bootstrap.api.ServiceRegistry;
-import org.jboss.weld.bootstrap.api.helpers.SimpleServiceRegistry;
-import org.jboss.weld.bootstrap.spi.BeanDeploymentArchive;
-import org.jboss.weld.bootstrap.spi.BeanDiscoveryMode;
-import org.jboss.weld.bootstrap.spi.BeansXml;
-import org.jboss.weld.bootstrap.spi.Deployment;
-import org.jboss.weld.bootstrap.spi.Metadata;
-import org.jboss.weld.bootstrap.spi.Scanning;
-import org.jboss.weld.environment.se.WeldSEBeanRegistrant;
-import org.jboss.weld.metadata.BeansXmlImpl;
-import org.jboss.weld.resources.spi.ResourceLoader;
-import org.jglue.cdiunit.ActivatedAlternatives;
-import org.jglue.cdiunit.AdditionalClasses;
-import org.jglue.cdiunit.AdditionalClasspaths;
-import org.jglue.cdiunit.AdditionalPackages;
-import org.jglue.cdiunit.CdiRunner;
-import org.jglue.cdiunit.ProducesAlternative;
-import org.jglue.cdiunit.internal.easymock.EasyMockExtension;
-import org.jglue.cdiunit.internal.jsf.ViewScopeExtension;
-import org.jglue.cdiunit.internal.mockito.MockitoExtension;
-import org.jglue.cdiunit.internal.servlet.MockHttpServletRequestImpl;
-import org.jglue.cdiunit.internal.servlet.MockHttpServletResponseImpl;
-import org.jglue.cdiunit.internal.servlet.MockHttpSessionImpl;
-import org.jglue.cdiunit.internal.servlet.MockServletContextImpl;
-import org.jglue.cdiunit.internal.servlet.ServletObjectsProducer;
-import org.mockito.Mock;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.*;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.security.CodeSource;
+import java.util.*;
+import java.util.jar.Attributes;
+import java.util.jar.JarInputStream;
+import java.util.jar.Manifest;
+import java.util.stream.Collectors;
 
 public class WeldTestUrlDeployment implements Deployment {
 	private final BeanDeploymentArchive beanDeploymentArchive;
@@ -402,7 +374,7 @@ public class WeldTestUrlDeployment implements Deployment {
 				}
 				// TODO beans.xml is no longer required by CDI (1.1+)
 				URL beansXml = classLoader.getResource("META-INF/beans.xml");
-				boolean isCdiUnit = url.equals(getClasspathURL(CdiRunner.class));
+				boolean isCdiUnit = url.equals(getClasspathURL("org.jglue.cdiunit.CdiRunner"));
 				if (isCdiUnit || beansXml != null || isDirectory(url)) {
 					cdiClasspathEntries.add(url);
 				}
@@ -414,6 +386,17 @@ public class WeldTestUrlDeployment implements Deployment {
 		}
 	}
 
+	private URL getClasspathURL(String className) {
+		try {
+			final Class<?> clazz = Class.forName(className);
+			return getClasspathURL(clazz);
+		} catch (ClassNotFoundException | NoClassDefFoundError clnfe) {
+			// NoClassDefFoundError  may bau caught as CdiRunner is available on the classpath but
+			// BlockJUnit4ClassRunner is not
+			return null;
+		}
+	}
+	
 	private URL getClasspathURL(Class<?> clazz) {
 		CodeSource codeSource = clazz.getProtectionDomain()
 				.getCodeSource();


### PR DESCRIPTION
Apparently, using CDIUnit in combination with TestNG strictly requires JUnit 4 on the classpath. 

When leaving out the dependency `junit:junit:4.12` in my `pom.xml`, CDIUnit tests fail because the `org.junit.runners.BlockJUnit4ClassRunner` is missing:

```
java.lang.NoClassDefFoundError: org/junit/runners/BlockJUnit4ClassRunner
	at java.base/java.lang.ClassLoader.defineClass1(Native Method)
	at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1016)
	at java.base/java.security.SecureClassLoader.defineClass(SecureClassLoader.java:174)
	at java.base/jdk.internal.loader.BuiltinClassLoader.defineClass(BuiltinClassLoader.java:802)
	at java.base/jdk.internal.loader.BuiltinClassLoader.findClassOnClassPathOrNull(BuiltinClassLoader.java:700)
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClassOrNull(BuiltinClassLoader.java:623)
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:581)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:521)
	at org.jglue.cdiunit.internal.WeldTestUrlDeployment.populateCdiClasspathSet(WeldTestUrlDeployment.java:405)
	at org.jglue.cdiunit.internal.WeldTestUrlDeployment.<init>(WeldTestUrlDeployment.java:97)
	at org.jglue.cdiunit.NgCdiRunner$1.createDeployment(NgCdiRunner.java:49)
	at org.jboss.weld.environment.se.Weld.initialize(Weld.java:777)
	at org.jglue.cdiunit.NgCdiRunner.initializeCdi(NgCdiRunner.java:64)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:133)
	at org.testng.internal.MethodInvocationHelper.invokeMethodConsideringTimeout(MethodInvocationHelper.java:62)
	at org.testng.internal.ConfigInvoker.invokeConfigurationMethod(ConfigInvoker.java:340)
	at org.testng.internal.ConfigInvoker.invokeConfigurations(ConfigInvoker.java:294)
	at org.testng.internal.TestInvoker.runConfigMethods(TestInvoker.java:683)
	at org.testng.internal.TestInvoker.invokeMethod(TestInvoker.java:510)
	at org.testng.internal.TestInvoker.invokeTestMethod(TestInvoker.java:172)
	at org.testng.internal.MethodRunner.runInSequence(MethodRunner.java:46)
	at org.testng.internal.TestInvoker$MethodInvocationAgent.invoke(TestInvoker.java:804)
	at org.testng.internal.TestInvoker.invokeTestMethods(TestInvoker.java:145)
	at org.testng.internal.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:146)
	at org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:128)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1540)
	at org.testng.TestRunner.privateRun(TestRunner.java:770)
	at org.testng.TestRunner.run(TestRunner.java:591)
	at org.testng.SuiteRunner.runTest(SuiteRunner.java:402)
	at org.testng.SuiteRunner.runSequentially(SuiteRunner.java:396)
	at org.testng.SuiteRunner.privateRun(SuiteRunner.java:355)
	at org.testng.SuiteRunner.run(SuiteRunner.java:304)
	at org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:53)
```

Adding the JUnit 4 dependency makes the test pass. However, some other testing related frameworks might require an absence of JUnit for detecting a different like TestNG framework as the actually used testing framework.

The cause of this bug seems to be be caused by a "hard" reference on `org.jglue.cdiunit.internal.WeldTestUrlDeployment` in line 405 as `org.jglue.cdiunit.internal.CdiRunner` is derived from `BlockJUnit4ClassRunner`. This pull request contains a fix for it.