### PR TITLE
Performance: Cache class path scan results.

### DIFF
--- a/cdi-unit-tests-bare/pom.xml
+++ b/cdi-unit-tests-bare/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jglue.cdi-unit</groupId>
 		<artifactId>cdi-unit-parent</artifactId>
-		<version>4.1.1-SNAPSHOT</version>
+		<version>4.1.1-HL</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<name>CDI-Unit-Tests-Bare</name>

--- a/cdi-unit-tests-easymock/pom.xml
+++ b/cdi-unit-tests-easymock/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jglue.cdi-unit</groupId>
 		<artifactId>cdi-unit-parent</artifactId>
-		<version>4.1.1-SNAPSHOT</version>
+		<version>4.1.1-HL</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<name>CDI-Unit-Tests-EasyMock</name>

--- a/cdi-unit-tests-external-dependency/pom.xml
+++ b/cdi-unit-tests-external-dependency/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jglue.cdi-unit</groupId>
 		<artifactId>cdi-unit-parent</artifactId>
-		<version>4.1.1-SNAPSHOT</version>
+		<version>4.1.1-HL</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<name>CDI-Unit-Tests-ExternalDependency</name>

--- a/cdi-unit-tests-jandex/pom.xml
+++ b/cdi-unit-tests-jandex/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jglue.cdi-unit</groupId>
 		<artifactId>cdi-unit-parent</artifactId>
-		<version>4.1.1-SNAPSHOT</version>
+		<version>4.1.1-HL</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<name>CDI-Unit-Tests-Jandex</name>

--- a/cdi-unit-tests-mockito/pom.xml
+++ b/cdi-unit-tests-mockito/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jglue.cdi-unit</groupId>
 		<artifactId>cdi-unit-parent</artifactId>
-		<version>4.1.1-SNAPSHOT</version>
+		<version>4.1.1-HL</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<name>CDI-Unit-Tests-Mockito</name>

--- a/cdi-unit-tests/pom.xml
+++ b/cdi-unit-tests/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jglue.cdi-unit</groupId>
 		<artifactId>cdi-unit-parent</artifactId>
-		<version>4.1.1-SNAPSHOT</version>
+		<version>4.1.1-HL</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<name>CDI-Unit-Tests</name>

--- a/cdi-unit/pom.xml
+++ b/cdi-unit/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.jglue.cdi-unit</groupId>
 		<artifactId>cdi-unit-parent</artifactId>
-		<version>4.1.1-SNAPSHOT</version>
+		<version>4.1.1-HL</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<name>CDI-Unit</name>

--- a/cdi-unit/src/main/java/org/jglue/cdiunit/internal/ClassGraphScanner.java
+++ b/cdi-unit/src/main/java/org/jglue/cdiunit/internal/ClassGraphScanner.java
@@ -10,13 +10,21 @@ import io.github.classgraph.ScanResult;
  * @author Sean Flanigan <a href="mailto:sflaniga@redhat.com">sflaniga@redhat.com</a>
  */
 public class ClassGraphScanner implements ClasspathScanner {
+    private static ClassGraphScanner instance = new ClassGraphScanner();
+
+    private List<URL> classpathURLs;
 
     @Override
     public List<URL> getClasspathURLs() {
+        if (classpathURLs != null) {
+          return classpathURLs;
+        }
+
         try (ScanResult scan = new ClassGraph()
                 .disableNestedJarScanning()
                 .scan()) {
-            return scan.getClasspathURLs();
+          classpathURLs = scan.getClasspathURLs();
+          return classpathURLs;
         }
     }
 
@@ -28,12 +36,14 @@ public class ClassGraphScanner implements ClasspathScanner {
                 .ignoreClassVisibility()
                 .overrideClasspath(urls)
                 .scan()) {
-            return scan.getAllClasses().getNames();
+	    return scan.getAllClasses().getNames();
         }
     }
 
     @Override
     public List<String> getClassNamesForPackage(String packageName, URL url) {
+	
+
         try (ScanResult scan = new ClassGraph()
                 .disableNestedJarScanning()
                 .enableClassInfo()
@@ -41,7 +51,11 @@ public class ClassGraphScanner implements ClasspathScanner {
                 .overrideClasspath(url)
                 .whitelistPackagesNonRecursive(packageName)
                 .scan()) {
-            return scan.getAllClasses().getNames();
+	    return scan.getAllClasses().getNames();
         }
+    }
+
+    public static ClassGraphScanner getInstance() {
+	    return instance;
     }
 }

--- a/cdi-unit/src/main/java/org/jglue/cdiunit/internal/WeldTestUrlDeployment.java
+++ b/cdi-unit/src/main/java/org/jglue/cdiunit/internal/WeldTestUrlDeployment.java
@@ -86,7 +86,7 @@ import org.slf4j.LoggerFactory;
 
 public class WeldTestUrlDeployment implements Deployment {
 	private final BeanDeploymentArchive beanDeploymentArchive;
-	private ClasspathScanner scanner = new ClassGraphScanner();
+	private ClasspathScanner scanner = ClassGraphScanner.getInstance();
 	private Collection<Metadata<Extension>> extensions = new ArrayList<>();
 	private static final Logger log = LoggerFactory.getLogger(WeldTestUrlDeployment.class);
 	private Set<URL> cdiClasspathEntries = new HashSet<>();
@@ -471,10 +471,12 @@ public class WeldTestUrlDeployment implements Deployment {
 		return extensions;
 	}
 
+	@Override
 	public List<BeanDeploymentArchive> getBeanDeploymentArchives() {
 		return Collections.singletonList(beanDeploymentArchive);
 	}
 
+	@Override
 	public BeanDeploymentArchive loadBeanDeploymentArchive(Class<?> beanClass) {
 		return beanDeploymentArchive;
 	}

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.jglue.cdi-unit</groupId>
 	<artifactId>cdi-unit-parent</artifactId>
-	<version>4.1.1-SNAPSHOT</version>
+	<version>4.1.1-HL</version>
 	<packaging>pom</packaging>
 	<parent>
 		<groupId>org.sonatype.oss</groupId>


### PR DESCRIPTION
For a large project and a test with a lot of test methods caching the class path scanner results descreases test runtime by about 50%.