### PR TITLE
Feature cache class scan

### DIFF
--- a/cdi-unit/src/main/java/org/jglue/cdiunit/internal/BeanArchiveScanner.java
+++ b/cdi-unit/src/main/java/org/jglue/cdiunit/internal/BeanArchiveScanner.java
@@ -1,0 +1,14 @@
+package org.jglue.cdiunit.internal;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Collection;
+
+/**
+ * Scanner for bean archives.
+ */
+public interface BeanArchiveScanner {
+
+	Collection<URL> findBeanArchives(Collection<URL> classPathEntries) throws IOException;
+
+}

--- a/cdi-unit/src/main/java/org/jglue/cdiunit/internal/CachingClassGraphScanner.java
+++ b/cdi-unit/src/main/java/org/jglue/cdiunit/internal/CachingClassGraphScanner.java
@@ -6,93 +6,118 @@ import io.github.classgraph.utils.AutoCloseableExecutorService;
 import java.io.File;
 import java.net.URL;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.deltaspike.core.util.ExceptionUtils;
 
 /**
  * @author Illya Kysil <a href="mailto:ikysil@ikysil.name">ikysil@ikysil.name</a>
  */
 public class CachingClassGraphScanner implements ClasspathScanner {
 
-    /**
-     * The default number of worker threads to use while scanning. This number gave the best results on a relatively
-     * modern laptop with SSD, while scanning a large classpath.
-     */
-    static final int DEFAULT_NUM_WORKER_THREADS = Math.max(
-        // Always scan with at least 2 threads
-        2, //
-        (int) Math.ceil(
-            // Num IO threads (top out at 4, since most I/O devices won't scale better than this)
-            Math.min(4.0f, Runtime.getRuntime().availableProcessors() * 0.75f) +
-                // Num scanning threads (higher than available processors, because some threads can be blocked)
-                Runtime.getRuntime().availableProcessors() * 1.25f) //
-    );
+	/**
+	 * The default number of worker threads to use while scanning. This number gave the best results on a relatively
+	 * modern laptop with SSD, while scanning a large classpath.
+	 */
+	static final int DEFAULT_NUM_WORKER_THREADS = Math.max(
+		// Always scan with at least 2 threads
+		2, //
+		(int) Math.ceil(
+			// Num IO threads (top out at 4, since most I/O devices won't scale better than this)
+			Math.min(4.0f, Runtime.getRuntime().availableProcessors() * 0.75f) +
+				// Num scanning threads (higher than available processors, because some threads can be blocked)
+				Runtime.getRuntime().availableProcessors() * 1.25f) //
+	);
 
-    static final ExecutorService scanExecutor = new AutoCloseableExecutorService(DEFAULT_NUM_WORKER_THREADS);
+	static final ExecutorService scanExecutor = new AutoCloseableExecutorService(DEFAULT_NUM_WORKER_THREADS);
 
-    static ConcurrentHashMap<Object, Object> cache = new ConcurrentHashMap<>();
+	static ConcurrentHashMap<Object, Object> cache = new ConcurrentHashMap<>();
 
-    @SuppressWarnings("unchecked")
-    private <K, V> V computeIfAbsent(final K k, final Supplier<V> computeValue) {
-        return (V) cache.computeIfAbsent(k, o -> computeValue.get());
-    }
+	private final BeanArchiveScanner beanArchiveScanner;
 
-    @Override
-    public List<URL> getClasspathURLs() {
-        return computeIfAbsent(getClass().getClassLoader(), this::computeClasspathUrls);
-    }
+	public CachingClassGraphScanner(final BeanArchiveScanner beanArchiveScanner) {
+		this.beanArchiveScanner = beanArchiveScanner;
+	}
 
-    private List<URL> computeClasspathUrls() {
-        try (ScanResult scan = new ClassGraph()
-            .disableNestedJarScanning()
-            .scan(scanExecutor, DEFAULT_NUM_WORKER_THREADS)) {
-            return scan.getClasspathURLs();
-        }
-    }
+	@SuppressWarnings("unchecked")
+	private <K, V> V computeIfAbsent(final K k, final Supplier<V> computeValue) {
+		return (V) cache.computeIfAbsent(k, o -> computeValue.get());
+	}
 
-    @Override
-    public List<String> getClassNamesForClasspath(URL[] urls) {
-        return computeIfAbsent(computeKey(urls), () -> this.computeClassNamesForClasspath(urls));
-    }
+	private List<URL> getClasspathURLs() {
+		return computeIfAbsent(getClass().getClassLoader(), this::computeClasspathUrls);
+	}
 
-    private Object computeKey(final URL[] urls) {
-        return Arrays.stream(urls)
-            .map(URL::toString)
-            .collect(Collectors.joining(File.pathSeparator));
-    }
+	@Override
+	public Collection<URL> getBeanArchives() {
+		final List<URL> urls = getClasspathURLs();
+		return computeIfAbsent(computeKey(urls.stream()), () -> findBeanArchives(urls));
+	}
 
-    private List<String> computeClassNamesForClasspath(URL[] urls) {
-        try (ScanResult scan = new ClassGraph()
-                .disableNestedJarScanning()
-                .enableClassInfo()
-                .ignoreClassVisibility()
-                .overrideClasspath(urls)
-                .scan(scanExecutor, DEFAULT_NUM_WORKER_THREADS)) {
-            return scan.getAllClasses().getNames();
-        }
-    }
+	private Collection<URL> findBeanArchives(final List<URL> urls) {
+		try {
+			return beanArchiveScanner.findBeanArchives(urls);
+		} catch (Exception e) {
+			ExceptionUtils.throwAsRuntimeException(e);
+		}
+		return Collections.emptyList();
+	}
 
-    @Override
-    public List<String> getClassNamesForPackage(String packageName, URL url) {
-        return computeIfAbsent(computeKey(packageName, url), () -> this.computeClassNamesForPackage(packageName, url));
-    }
+	private List<URL> computeClasspathUrls() {
+		try (ScanResult scan = new ClassGraph()
+			.disableNestedJarScanning()
+			.scan(scanExecutor, DEFAULT_NUM_WORKER_THREADS)) {
+			return scan.getClasspathURLs();
+		}
+	}
 
-    private Object computeKey(final String packageName, final URL url) {
-        return String.format("%s@%s", packageName, url);
-    }
+	@Override
+	public List<String> getClassNamesForClasspath(URL[] urls) {
+		return computeIfAbsent(computeKey(Arrays.stream(urls)), () -> this.computeClassNamesForClasspath(urls));
+	}
 
-    private List<String> computeClassNamesForPackage(String packageName, URL url) {
-        try (ScanResult scan = new ClassGraph()
-                .disableNestedJarScanning()
-                .enableClassInfo()
-                .ignoreClassVisibility()
-                .overrideClasspath(url)
-                .whitelistPackagesNonRecursive(packageName)
-                .scan(scanExecutor, DEFAULT_NUM_WORKER_THREADS)) {
-            return scan.getAllClasses().getNames();
-        }
-    }
+	private Object computeKey(final Stream<URL> urls) {
+		return urls
+			.map(URL::toString)
+			.collect(Collectors.joining(File.pathSeparator));
+	}
+
+	private List<String> computeClassNamesForClasspath(URL[] urls) {
+		try (ScanResult scan = new ClassGraph()
+				.disableNestedJarScanning()
+				.enableClassInfo()
+				.ignoreClassVisibility()
+				.overrideClasspath(urls)
+				.scan(scanExecutor, DEFAULT_NUM_WORKER_THREADS)) {
+			return scan.getAllClasses().getNames();
+		}
+	}
+
+	@Override
+	public List<String> getClassNamesForPackage(String packageName, URL url) {
+		return computeIfAbsent(computeKey(packageName, url), () -> this.computeClassNamesForPackage(packageName, url));
+	}
+
+	private Object computeKey(final String packageName, final URL url) {
+		return String.format("%s@%s", packageName, url);
+	}
+
+	private List<String> computeClassNamesForPackage(String packageName, URL url) {
+		try (ScanResult scan = new ClassGraph()
+				.disableNestedJarScanning()
+				.enableClassInfo()
+				.ignoreClassVisibility()
+				.overrideClasspath(url)
+				.whitelistPackagesNonRecursive(packageName)
+				.scan(scanExecutor, DEFAULT_NUM_WORKER_THREADS)) {
+			return scan.getAllClasses().getNames();
+		}
+	}
+
 }

--- a/cdi-unit/src/main/java/org/jglue/cdiunit/internal/CachingClassGraphScanner.java
+++ b/cdi-unit/src/main/java/org/jglue/cdiunit/internal/CachingClassGraphScanner.java
@@ -1,0 +1,98 @@
+package org.jglue.cdiunit.internal;
+
+import io.github.classgraph.ClassGraph;
+import io.github.classgraph.ScanResult;
+import io.github.classgraph.utils.AutoCloseableExecutorService;
+import java.io.File;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+/**
+ * @author Illya Kysil <a href="mailto:ikysil@ikysil.name">ikysil@ikysil.name</a>
+ */
+public class CachingClassGraphScanner implements ClasspathScanner {
+
+    /**
+     * The default number of worker threads to use while scanning. This number gave the best results on a relatively
+     * modern laptop with SSD, while scanning a large classpath.
+     */
+    static final int DEFAULT_NUM_WORKER_THREADS = Math.max(
+        // Always scan with at least 2 threads
+        2, //
+        (int) Math.ceil(
+            // Num IO threads (top out at 4, since most I/O devices won't scale better than this)
+            Math.min(4.0f, Runtime.getRuntime().availableProcessors() * 0.75f) +
+                // Num scanning threads (higher than available processors, because some threads can be blocked)
+                Runtime.getRuntime().availableProcessors() * 1.25f) //
+    );
+
+    static final ExecutorService scanExecutor = new AutoCloseableExecutorService(DEFAULT_NUM_WORKER_THREADS);
+
+    static ConcurrentHashMap<Object, Object> cache = new ConcurrentHashMap<>();
+
+    @SuppressWarnings("unchecked")
+    private <K, V> V computeIfAbsent(final K k, final Supplier<V> computeValue) {
+        return (V) cache.computeIfAbsent(k, o -> computeValue.get());
+    }
+
+    @Override
+    public List<URL> getClasspathURLs() {
+        return computeIfAbsent(getClass().getClassLoader(), this::computeClasspathUrls);
+    }
+
+    private List<URL> computeClasspathUrls() {
+        try (ScanResult scan = new ClassGraph()
+            .disableNestedJarScanning()
+            .scan(scanExecutor, DEFAULT_NUM_WORKER_THREADS)) {
+            return scan.getClasspathURLs();
+        }
+    }
+
+    @Override
+    public List<String> getClassNamesForClasspath(URL[] urls) {
+        return computeIfAbsent(computeKey(urls), () -> this.computeClassNamesForClasspath(urls));
+    }
+
+    private Object computeKey(final URL[] urls) {
+        return Arrays.stream(urls)
+            .map(URL::toString)
+            .collect(Collectors.joining(File.pathSeparator));
+    }
+
+    private List<String> computeClassNamesForClasspath(URL[] urls) {
+        try (ScanResult scan = new ClassGraph()
+                .disableNestedJarScanning()
+                .enableClassInfo()
+                .ignoreClassVisibility()
+                .overrideClasspath(urls)
+                .scan(scanExecutor, DEFAULT_NUM_WORKER_THREADS)) {
+            return scan.getAllClasses().getNames();
+        }
+    }
+
+    @Override
+    public List<String> getClassNamesForPackage(String packageName, URL url) {
+        return computeIfAbsent(computeKey(packageName, url), () -> this.computeClassNamesForPackage(packageName, url));
+    }
+
+    private Object computeKey(final String packageName, final URL url) {
+        return String.format("%s@%s", packageName, url);
+    }
+
+    private List<String> computeClassNamesForPackage(String packageName, URL url) {
+        try (ScanResult scan = new ClassGraph()
+                .disableNestedJarScanning()
+                .enableClassInfo()
+                .ignoreClassVisibility()
+                .overrideClasspath(url)
+                .whitelistPackagesNonRecursive(packageName)
+                .scan(scanExecutor, DEFAULT_NUM_WORKER_THREADS)) {
+            return scan.getAllClasses().getNames();
+        }
+    }
+}

--- a/cdi-unit/src/main/java/org/jglue/cdiunit/internal/CachingClassGraphScanner.java
+++ b/cdi-unit/src/main/java/org/jglue/cdiunit/internal/CachingClassGraphScanner.java
@@ -2,7 +2,8 @@ package org.jglue.cdiunit.internal;
 
 import io.github.classgraph.ClassGraph;
 import io.github.classgraph.ScanResult;
-import io.github.classgraph.utils.AutoCloseableExecutorService;
+import org.apache.deltaspike.core.util.ExceptionUtils;
+
 import java.io.File;
 import java.net.URL;
 import java.util.Arrays;
@@ -11,10 +12,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.apache.deltaspike.core.util.ExceptionUtils;
 
 /**
  * @author Illya Kysil <a href="mailto:ikysil@ikysil.name">ikysil@ikysil.name</a>
@@ -35,7 +36,7 @@ public class CachingClassGraphScanner implements ClasspathScanner {
 				Runtime.getRuntime().availableProcessors() * 1.25f) //
 	);
 
-	static final ExecutorService scanExecutor = new AutoCloseableExecutorService(DEFAULT_NUM_WORKER_THREADS);
+	static final ExecutorService scanExecutor = Executors.newWorkStealingPool(DEFAULT_NUM_WORKER_THREADS);
 
 	static ConcurrentHashMap<Object, Object> cache = new ConcurrentHashMap<>();
 
@@ -93,7 +94,7 @@ public class CachingClassGraphScanner implements ClasspathScanner {
 				.disableNestedJarScanning()
 				.enableClassInfo()
 				.ignoreClassVisibility()
-				.overrideClasspath(urls)
+				.overrideClasspath(Arrays.asList(urls))
 				.scan(scanExecutor, DEFAULT_NUM_WORKER_THREADS)) {
 			return scan.getAllClasses().getNames();
 		}

--- a/cdi-unit/src/main/java/org/jglue/cdiunit/internal/ClassGraphScanner.java
+++ b/cdi-unit/src/main/java/org/jglue/cdiunit/internal/ClassGraphScanner.java
@@ -1,23 +1,42 @@
 package org.jglue.cdiunit.internal;
 
 import java.net.URL;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 import io.github.classgraph.ClassGraph;
 import io.github.classgraph.ScanResult;
+import org.apache.deltaspike.core.util.ExceptionUtils;
 
 /**
  * @author Sean Flanigan <a href="mailto:sflaniga@redhat.com">sflaniga@redhat.com</a>
  */
-public class ClassGraphScanner implements ClasspathScanner {
+class ClassGraphScanner implements ClasspathScanner {
 
-    @Override
-    public List<URL> getClasspathURLs() {
+    private final BeanArchiveScanner beanArchiveScanner;
+
+    ClassGraphScanner(final BeanArchiveScanner beanArchiveScanner) {
+        this.beanArchiveScanner = beanArchiveScanner;
+    }
+
+    private List<URL> getClasspathURLs() {
         try (ScanResult scan = new ClassGraph()
                 .disableNestedJarScanning()
                 .scan()) {
             return scan.getClasspathURLs();
         }
+    }
+
+    @Override
+    public Collection<URL> getBeanArchives() {
+        final List<URL> urls = getClasspathURLs();
+        try {
+            return beanArchiveScanner.findBeanArchives(urls);
+        } catch (Exception e) {
+            ExceptionUtils.throwAsRuntimeException(e);
+        }
+        return Collections.emptyList();
     }
 
     @Override

--- a/cdi-unit/src/main/java/org/jglue/cdiunit/internal/ClasspathScanner.java
+++ b/cdi-unit/src/main/java/org/jglue/cdiunit/internal/ClasspathScanner.java
@@ -1,13 +1,14 @@
 package org.jglue.cdiunit.internal;
 
 import java.net.URL;
+import java.util.Collection;
 import java.util.List;
 
 /**
  * @author Sean Flanigan <a href="mailto:sflaniga@redhat.com">sflaniga@redhat.com</a>
  */
 public interface ClasspathScanner {
-    List<URL> getClasspathURLs();
+    Collection<URL> getBeanArchives();
     List<String> getClassNamesForClasspath(URL[] urls);
     List<String> getClassNamesForPackage(String packageName, URL url);
 }

--- a/cdi-unit/src/main/java/org/jglue/cdiunit/internal/DefaultBeanArchiveScanner.java
+++ b/cdi-unit/src/main/java/org/jglue/cdiunit/internal/DefaultBeanArchiveScanner.java
@@ -1,0 +1,105 @@
+package org.jglue.cdiunit.internal;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.security.CodeSource;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.jar.Attributes;
+import java.util.jar.JarInputStream;
+import java.util.jar.Manifest;
+import org.jglue.cdiunit.CdiRunner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DefaultBeanArchiveScanner implements BeanArchiveScanner {
+
+	private static final Logger log = LoggerFactory.getLogger(DefaultBeanArchiveScanner.class);
+
+	@Override
+	public Collection<URL> findBeanArchives(final Collection<URL> classPathEntries) throws IOException {
+		final Set<URL> result = new HashSet<>();
+		// cdiClasspathEntries doesn't preserve order, so HashSet is fine
+		final Set<URL> entrySet = new HashSet<>(classPathEntries);
+
+		for (URL url : classPathEntries) {
+			entrySet.addAll(getEntriesFromManifestClasspath(url));
+		}
+
+		for (URL url : entrySet) {
+			try (URLClassLoader classLoader = new URLClassLoader(new URL[]{ url },
+				null)) {
+				// TODO this seems pretty Maven-specific, and fragile
+				if (url.getFile().endsWith("/classes/")) {
+					URL webInfBeans = new URL(url,
+						"../../src/main/webapp/WEB-INF/beans.xml");
+					try (InputStream ignore = webInfBeans.openStream()) {
+						result.add(url);
+					} catch (IOException ignore) {
+						// no such file
+					}
+				}
+				// TODO beans.xml is no longer required by CDI (1.1+)
+				URL beansXml = classLoader.getResource("META-INF/beans.xml");
+				boolean isCdiUnit = url.equals(getClasspathURL(CdiRunner.class));
+				if (isCdiUnit || beansXml != null || isDirectory(url)) {
+					result.add(url);
+				}
+			}
+		}
+		log.debug("CDI classpath entries discovered:");
+		for (URL url : result) {
+			log.debug("{}", url);
+		}
+		return result;
+	}
+
+	private URL getClasspathURL(Class<?> clazz) {
+		CodeSource codeSource = clazz.getProtectionDomain()
+			.getCodeSource();
+		return codeSource != null ? codeSource.getLocation() : null;
+	}
+
+	private boolean isDirectory(URL classpathEntry) {
+		try {
+			return new File(classpathEntry.toURI()).isDirectory();
+		} catch (IllegalArgumentException ignore) {
+			// Ignore, thrown by File constructor for unsupported URIs
+		} catch (URISyntaxException ignore) {
+			// Ignore, does not denote an URI that points to a directory
+		}
+		return false;
+	}
+
+	private static Set<URL> getEntriesFromManifestClasspath(URL url)
+		throws IOException {
+		Set<URL> manifestURLs = new HashSet<>();
+		// If this is a surefire manifest-only jar we need to get the original classpath.
+		// When testing cdi-unit-tests through Maven, this finds extra entries compared to FCS:
+		// eg ".../cdi-unit/cdi-unit-tests/target/classes"
+		try (InputStream in = url.openStream();
+			 JarInputStream jar = new JarInputStream(in)) {
+			Manifest manifest = jar.getManifest();
+			if (manifest != null) {
+				String classpath = (String) manifest.getMainAttributes()
+					.get(Attributes.Name.CLASS_PATH);
+				if (classpath != null) {
+					String[] manifestEntries = classpath.split(" ?file:");
+					for (String entry : manifestEntries) {
+						if (entry.length() > 0) {
+							// entries is a Set, so this won't add duplicates
+							manifestURLs.add(new URL("file:" + entry));
+						}
+					}
+				}
+			}
+		}
+		return manifestURLs;
+	}
+
+}

--- a/cdi-unit/src/main/java/org/jglue/cdiunit/internal/WeldTestUrlDeployment.java
+++ b/cdi-unit/src/main/java/org/jglue/cdiunit/internal/WeldTestUrlDeployment.java
@@ -87,7 +87,7 @@ import org.slf4j.LoggerFactory;
 
 public class WeldTestUrlDeployment implements Deployment {
 	private final BeanDeploymentArchive beanDeploymentArchive;
-	private ClasspathScanner scanner = new ClassGraphScanner();
+	private ClasspathScanner scanner = new CachingClassGraphScanner();
 	private Collection<Metadata<Extension>> extensions = new ArrayList<>();
 	private static final Logger log = LoggerFactory.getLogger(WeldTestUrlDeployment.class);
 	private Set<URL> cdiClasspathEntries = new HashSet<>();


### PR DESCRIPTION
Performance improvements for projects with a large number of classes.

1. Do not create a new thread pool on every invocation of `Classgraph.scan()`, reuse one instance.
2. Cache results of `Classgraph.scan()`.
3. Cache results of the scan for bean archives - former `WeldTestUrlDeployment#populateCdiClasspathSet`

`mvn surefire:test` execution time:
1. Stock cdi-unit 4.1.0: 11:30 min
2. Modifications 1 and 2 above applied: 04:25 min
3. All modifications above applied: 03:16 min
