### PR TITLE
Remove redundant dependencies

### DIFF
--- a/cdi-unit-tests-external-dependency/pom.xml
+++ b/cdi-unit-tests-external-dependency/pom.xml
@@ -23,19 +23,5 @@
 			</plugin>
 		</plugins>
 	</build>
-	<dependencies>
-
-		<dependency>
-			<groupId>javax.enterprise</groupId>
-			<artifactId>cdi-api</artifactId>
-			<version>1.2</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.deltaspike.core</groupId>
-			<artifactId>deltaspike-core-impl</artifactId>
-			<version>${deltaspike.version.baseline}</version>
-		</dependency>
-	</dependencies>
 
 </project>


### PR DESCRIPTION
@ikysil Hi, I am a user of project **_org.jglue.cdi-unit:cdi-unit-tests-external-dependency:4.1.1-SNAPSHOT_**. I found that its pom file introduced **_7_** dependencies. However, among them, **_6_** libraries (**_85%_**) have not been used by your project (the redundant dependencies are listed below). Reduce these useless dependencies can help prevent conflicts between library versions. MeanWhile, it can minimize the total added size to projects. It can also help enable advanced scenarios for users of your package. 
This PR helps **_org.jglue.cdi-unit:cdi-unit-tests-external-dependency:4.1.1-SNAPSHOT_** lose weight :) I have tested the revised configuration in my local environment. It is safe to remove the unused libraries.

Best regards


## Redundant dependencies----
<pre><code>
org.apache.deltaspike.core:deltaspike-core-api:jar:1.1.0:compile
javax.inject:javax.inject:jar:1:compile
org.apache.deltaspike.core:deltaspike-core-impl:jar:1.1.0:compile
javax.enterprise:cdi-api:jar:1.2:compile
javax.el:javax.el-api:jar:3.0.0:compile
javax.interceptor:javax.interceptor-api:jar:1.2:compile
</code></pre>