### PR TITLE
ci: Test Spock with Groovy 2.5 - known working combinations

### DIFF
--- a/.github/workflows/build-test-temurin.yml
+++ b/.github/workflows/build-test-temurin.yml
@@ -141,6 +141,11 @@ jobs:
           # FIXME - #330 - v2.5
           - v3.0
           - v4.0
+        include:
+          - java: 11
+            groovy: v2.5
+          - java: 17
+            groovy: v2.5
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-test-zulujdk.yml
+++ b/.github/workflows/build-test-zulujdk.yml
@@ -141,6 +141,11 @@ jobs:
           # FIXME - #330 - v2.5
           - v3.0
           - v4.0
+        include:
+          - java: 11
+            groovy: v2.5
+          - java: 17
+            groovy: v2.5
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Bring back Groovy 2.5 testing with known working Java versions.
See #330 